### PR TITLE
Suppress progress bars when silent = TRUE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Updated to latest schema structure (add 'snps' table, and rename 'archives' to 'returns')
 * Updated `README.md` to reflect schema changes
 * Added rmarkdown to 'Suggests' in `DESCRIPTION` for `README.Rmd` rendering
+* Fixed progress bars appearing when `silent = TRUE`
 
 # [ukbschemas 0.2.1](https://github.com/bjcairns/ukbschemas/tree/v0.2.1|)
 

--- a/R/misc-functions.R
+++ b/R/misc-functions.R
@@ -59,9 +59,19 @@
 ) {
   
   # Read each schema directly from the UK Biobank Data Showcase by ID
+  
+  # Hide column parsing report and progress bars if silent = TRUE
   if (silent) {
-    on.exit(options(readr.num_columns = getOption("readr.num_columns")))
-    options(readr.num_columns = 0)
+    on.exit(
+      options(
+        readr.num_columns = getOption("readr.num_columns"),
+        readr.show_progress = getOption("readr.show_progress")
+      )
+    )
+    options(
+      readr.num_columns = 0, 
+      readr.show_progress = FALSE
+    )
   }
   
   # Download the files

--- a/tests/testthat/test-ukbschemas.R
+++ b/tests/testthat/test-ukbschemas.R
@@ -40,6 +40,11 @@ test_that("ukbschemas() runs silently if required", {
   
   expect_silent(sch <- ukbschemas(silent = TRUE, url_prefix = use_prefix))
   
+  # There seems to be no way to force readr to show a progress bar when 
+  # reading small files or over fast connections (estimated read time <5
+  # seconds), but if there was, this is where a further test would go to 
+  # ensure progress bars are always suppressed when silent = TRUE.
+  
 })
 
 test_that("ukbschemas() returns schemas in the right order", {


### PR DESCRIPTION
Uses the readr option `readr.show_progress = FALSE` to suppress progress bars.

A comment has been added to tests since there is no way to *force* progress bars for small files or fast connections.