### PR TITLE
Fixed a NAMESPACE issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ukbschemas
 Type: Package
 Title: Download the UK Biobank data schemas to an SQLite database
-Version: 0.2.1
+Version: 0.2.2
 Author: Benjamin J. Cairns <ben.cairns@ndph.ox.ac.uk>
 Maintainer: Benjamin J. Cairns <ben.cairns@ndph.ox.ac.uk>
 Description: ukbschema downloads the UK Biobank data dictionaries (schemas) from the UK Biobank Data Showcase and stores them in an SQLite database. The database can be loaded back into R, or queried using sqlite3 or any of a wide range of computing packages.
@@ -9,10 +9,10 @@ License: MIT + file LICENSE
 LazyData: true
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.1.1
 Depends:
     R (>= 2.10)
-Imports: 
+Imports:
     DBI,
     RSQLite,
     tibble,
@@ -23,7 +23,7 @@ Imports:
     stringr,
     utils,
     rlang
-Suggests: 
+Suggests:
     testthat,
     curl,
     here

--- a/R/tidy-schemas.R
+++ b/R/tidy-schemas.R
@@ -61,7 +61,7 @@
         dplyr::mutate(.x, parent_id = NA, selectable = NA) %>%
           dplyr::mutate(type = type, value = as.character(value)) %>%
           dplyr::group_by(encoding_id) %>%
-          dplyr::mutate(code_id = row_number()) %>%
+          dplyr::mutate(code_id = dplyr::row_number()) %>%
           dplyr::ungroup()
       }
     )

--- a/man/save_db.Rd
+++ b/man/save_db.Rd
@@ -4,8 +4,15 @@
 \alias{save_db}
 \title{Save a list of UK Biobank data schemas to an SQLite database}
 \usage{
-save_db(sch, file = "", path = ".", date_str = Sys.Date(),
-  silent = !interactive(), overwrite = FALSE, as_is = FALSE)
+save_db(
+  sch,
+  file = "",
+  path = ".",
+  date_str = Sys.Date(),
+  silent = !interactive(),
+  overwrite = FALSE,
+  as_is = FALSE
+)
 }
 \arguments{
 \item{sch}{List of tibbles, representing UK Biobank data schemas (unless

--- a/man/ukbschemas.Rd
+++ b/man/ukbschemas.Rd
@@ -4,8 +4,7 @@
 \alias{ukbschemas}
 \title{Load the UK Biobank data schemas from the Internet or other repository}
 \usage{
-ukbschemas(silent = !interactive(), as_is = FALSE,
-  url_prefix = UKB_URL_PREFIX)
+ukbschemas(silent = !interactive(), as_is = FALSE, url_prefix = UKB_URL_PREFIX)
 }
 \arguments{
 \item{silent}{Do not report progress. Defaults to \code{FALSE}.}
@@ -15,7 +14,7 @@ to \code{FALSE}.}
 
 \item{url_prefix}{First part of the URL at which the schema files can be
 found. For local repositories, the directory with a trailing delimiter (i.e.
-\code{/} or \code{\\} or \code{\\\\} as appropriate to your operating system).}
+\code{/} or \verb{\\\\} or \verb{\\\\\\\\} as appropriate to your operating system).}
 }
 \value{
 A list of objects of class \code{tbl_df} (see \link[tibble:tibble]{tibble::tibble}).

--- a/man/ukbschemas_db.Rd
+++ b/man/ukbschemas_db.Rd
@@ -4,9 +4,15 @@
 \alias{ukbschemas_db}
 \title{Create UK Biobank data schema database}
 \usage{
-ukbschemas_db(file = "", path = ".", date_str = Sys.Date(),
-  overwrite = FALSE, silent = !interactive(), as_is = FALSE,
-  url_prefix = UKB_URL_PREFIX)
+ukbschemas_db(
+  file = "",
+  path = ".",
+  date_str = Sys.Date(),
+  overwrite = FALSE,
+  silent = !interactive(),
+  as_is = FALSE,
+  url_prefix = UKB_URL_PREFIX
+)
 }
 \arguments{
 \item{file}{The filename for the schema database. Defaults to \code{""}, which is
@@ -31,7 +37,7 @@ to \code{FALSE}.}
 
 \item{url_prefix}{First part of the URL at which the schema files can be
 found. For local repositories, the directory with a trailing delimiter (i.e.
-\code{/} or \code{\\} or \code{\\\\} as appropriate to your operating system).}
+\code{/} or \verb{\\\\} or \verb{\\\\\\\\} as appropriate to your operating system).}
 }
 \value{
 A database connection object of class


### PR DESCRIPTION
- Fixed an issue with .tidy_schemas() whereby dplyr's row_number() function was missing it's  packagename plus "::" prefix.
- Re-ran roxygen2::roxygenise().
- Minor bump in version number in the 'Version' field of the DESCRIPTION file.