### PR TITLE
Tidied up the documentation and set line widths to 100 characters

### DIFF
--- a/R/load-db.R
+++ b/R/load-db.R
@@ -2,23 +2,20 @@
 #' Load schemas from a ukbschemas SQLite database
 #' 
 #' @description 
-#' `load_db()` is a simple front-end to [DBI] functions which can be used to
-#' load tables from a ukbschemas database (or in fact, any database; see
-#' [DBI::DBI-package]).
+#' `load_db()` is a simple front-end to [DBI] functions which can be used to load tables from a
+#' ukbschemas database (or in fact, any database; see [DBI::DBI-package]).
 #' 
 #' @param file Full path to an SQLite database, or `NULL`.
 #' @param db A (possibly disconnected) database connection, or `NULL`.
 #' 
 #' @details
-#' `load_db()` will attempt to open an SQLite database from file `file` or
-#' from connection `db`. It will throw errors if the file is not a valid
-#' database or it is impossible to create a valid connection from `db`. Tables
-#' are read with [DBI::dbReadTable] and converted to data frames. The database
-#' connection is always closed before the function returns its result.
+#' `load_db()` will attempt to open an SQLite database from file `file` or from connection `db`. It
+#' will throw errors if the file is not a valid database or it is impossible to create a valid
+#' connection from `db`. Tables are read with [DBI::dbReadTable] and converted to data frames. The
+#' database connection is always closed before the function returns its result.
 #' 
 #' @return
-#' A named list with elements of class `tbl_df`, containing the tables 
-#' from `db`.
+#' A named list with elements of class `data.frame`, containing the tables from `db`.
 #' 
 #' @examples 
 #' \dontrun{

--- a/R/save-db.R
+++ b/R/save-db.R
@@ -2,25 +2,23 @@
 #' Save a list of UK Biobank data schemas to an SQLite database
 #' 
 #' @description 
-#' `save_db()` saves a list of UK Biobank data schemas (or, if `as_is == TRUE`, 
-#' any list of data frames) to an SQLite database.
+#' `save_db()` saves a list of UK Biobank data schemas (or, if `as_is == TRUE`, any list of data
+#' frames) to an SQLite database.
 #' 
-#' @param sch List of data frames, representing UK Biobank data schemas (unless 
-#' `as_is == TRUE`, in which case any list of data frames is permitted)
-#' @param file The filename for the schema database. Defaults to `""`, which is 
-#' interpreted as `paste0("ukb-schemas-", date, ".sqlite")`. If this file 
-#' already exists in directory `path`, the session is interactive, and 
-#' `overwrite` is not `FALSE`, then the user will be prompted to decide whether 
-#' the file should be overwritten.
-#' @param path The path to the directory where the file will be saved. Defaults 
-#' to `.` (the current directory).
-#' @param date_str The date-stamp for the default filename. Defaults to the 
-#' current date in `YYYY-MM-DD` format.
+#' @param sch List of data frames, representing UK Biobank data schemas (unless `as_is == TRUE`, in
+#' which case any list of data frames is permitted).
+#' @param file The filename for the schema database. Defaults to `""`, which is interpreted as
+#' `paste0("ukb-schemas-", date, ".sqlite")`. If this file already exists in directory `path`, the
+#' session is interactive, and `overwrite` is not `FALSE`, then the user will be prompted to decide
+#' whether the file should be overwritten.
+#' @param path The path to the directory where the file will be saved. Defaults to `.` (the current
+#' directory).
+#' @param date_str The date-stamp for the default filename. Defaults to the current date in
+#' `YYYY-MM-DD` format.
 #' @param silent Do not report progress. Defaults to `FALSE`.
-#' @param overwrite Always overwrite existing files? Helpful for 
-#' non-interactive use. Defaults to `FALSE`.
-#' @param as_is Import the schemas into the database without tidying? Defaults 
-#' to `FALSE`.
+#' @param overwrite Always overwrite existing files? Helpful for non-interactive use. Defaults to
+#' `FALSE`.
+#' @param as_is Import the schemas into the database without tidying? Defaults to `FALSE`.
 #' 
 #' @return
 #' A database connection object of class 

--- a/R/ukbschemas-db.R
+++ b/R/ukbschemas-db.R
@@ -2,39 +2,30 @@
 #' Create UK Biobank data schema database
 #' 
 #' @description
-#' `ukbschemas_db()` generates an SQLite database containing the UK Biobank 
-#' data schemas from http://biobank.ctsu.ox.ac.uk/crystal/schema.cgi.
+#' `ukbschemas_db()` generates an SQLite database containing the UK Biobank data schemas from
+#' \url{http://biobank.ctsu.ox.ac.uk/crystal/schema.cgi}.
 #' 
-#' @param file The filename for the schema database. Defaults to `""`, which is 
-#' interpreted as `paste0("ukb-schemas-", date, ".sqlite")`. If this file 
-#' already exists in directory `path`, the session is interactive, and 
-#' `overwrite` is not `FALSE`, then the user will be prompted to decide whether 
-#' the file should be overwritten.
-#' @param path The path to the directory where the file will be saved. Defaults 
-#' to `.` (the current directory).
-#' @param sch_id The id numbers of the schemas to download. Type
-#' `SCHEMA_FILENAMES` for reference. Defaults to all.
-#' @param cache The directory path of the schema download cache. Defaults to
-#' `file.path(Sys.getenv("HOME"), "ukbschemas", "schemas")`.
-#' @param date_str The date-stamp for the default filename. Defaults to the
-#' current date in `YYYY-MM-DD` format.
-#' @param overwrite Always overwrite existing files? Helpful for non-interactive 
-#' use. Defaults to `FALSE`.
-#' @param nThread Number of threads to spawn for parallelisable tasks, such as
-#' the downloading and importing of the schemas. Defaults to the number of
-#' logical cores present on the system.
+#' @param file The filename for the schema database. Defaults to `""`, which is interpreted as
+#' `paste0("ukb-schemas-", date, ".sqlite")`. If this file already exists in directory `path`, the
+#' session is interactive, and `overwrite` is not `FALSE`, then the user will be prompted to decide
+#' whether the file should be overwritten.
+#' @param path The path to the directory where the file will be saved. Defaults to `.` (the current
+#' directory).
+#' @param date_str The date-stamp for the default filename. Defaults to the current date in
+#' `YYYY-MM-DD` format.
+#' @param overwrite Always overwrite existing files? Helpful for non-interactive use. Defaults to
+#' `FALSE`.
 #' @inheritParams ukbschemas
 #' 
 #' @return
 #' A database connection object of class [RSQLite::SQLiteConnection-class].
 #' 
 #' @details
-#' `ukbschemas_db()` uses [ukbschemas] to load the schemas and [save_db] to save
-#' the result.
+#' `ukbschemas_db()` uses [ukbschemas] to load the schemas and [save_db] to save the result.
 #' 
 #' @examples 
 #' \dontrun{
-#' db <- ukbschemas_db(db_path = tempdir())
+#' db <- ukbschemas_db(path = tempdir())
 #' }
 #' 
 #' @importFrom parallel detectCores

--- a/R/ukbschemas.R
+++ b/R/ukbschemas.R
@@ -2,32 +2,29 @@
 #' Load the UK Biobank data schemas from the Internet or other repository
 #' 
 #' @param silent Do not report progress. Defaults to `FALSE`.
-#' @param as_is Import the schemas into the database without tidying? Defaults 
-#' to `FALSE`.
-#' @param url_prefix First part of the URL at which the schema files can be 
-#' found. For local repositories, the directory with a trailing delimiter (i.e.
-#' `/` or `\\` or `\\\\` as appropriate to your operating system).
-#' @param sch_id The id numbers of the schemas to download. Type
-#' `SCHEMA_FILENAMES` for reference. Defaults to all.
+#' @param as_is Import the schemas into the database without tidying? Defaults to `FALSE`.
+#' @param url_prefix First part of the URL at which the schema files can be found. For local
+#' repositories, the directory with a trailing delimiter (i.e. `/` or `\\` or `\\\\` as appropriate
+#' to your operating system).
+#' @param sch_id The id numbers of the schemas to download. Type `SCHEMA_FILENAMES` for reference.
+#' Defaults to all.
 #' @param cache The directory path of the schema download cache. Defaults to
 #' `file.path(Sys.getenv("HOME"), "ukbschemas", "schemas")`.
-#' @param nThread Number of threads to spawn for parallelisable tasks, such as
-#' the downloading and importing of the schemas. Defaults to the number of
-#' logical cores present on the system.
+#' @param nThread Number of threads to spawn for parallelisable tasks, such as the downloading and
+#' importing of the schemas. Defaults to the number of logical cores present on the system.
 #' 
 #' @return
 #' A list of objects of class `data.frame`.
 #' 
 #' @details
-#' The UK Biobank data schemas are fetched via the Internet unless a  different
-#' `url_prefix` is provided. If `!as_is`, they are tidied. Note that  if the
-#' table structure has changed (i.e. has been changed by UK Biobank), then the
-#' function may fail partially or fully unless `as_is == TRUE`. 
+#' The UK Biobank data schemas are fetched via the Internet unless a  different `url_prefix` is
+#' provided. If `!as_is`, they are tidied. Note that  if the table structure has changed (i.e. has
+#' been changed by UK Biobank), then the function may fail partially or fully unless
+#' `as_is == TRUE`. 
 #'
 #' @note
-#' This is a convenience function to load the schemas directly from the UK
-#' Biobank website. For most purposes, it is recommended to use [ukbschemas_db]
-#' and [load_db] instead.
+#' This is a convenience function to load the schemas directly from the UK Biobank website. For most
+#' purposes, it is recommended to use [ukbschemas_db] and [load_db] instead.
 #'
 #' @examples 
 #' \dontrun{

--- a/man/load_db.Rd
+++ b/man/load_db.Rd
@@ -12,20 +12,17 @@ load_db(file = NULL, db = NULL)
 \item{db}{A (possibly disconnected) database connection, or \code{NULL}.}
 }
 \value{
-A named list with elements of class \code{tbl_df}, containing the tables
-from \code{db}.
+A named list with elements of class \code{data.frame}, containing the tables from \code{db}.
 }
 \description{
-\code{load_db()} is a simple front-end to \link{DBI} functions which can be used to
-load tables from a ukbschemas database (or in fact, any database; see
-\link[DBI:DBI-package]{DBI::DBI-package}).
+\code{load_db()} is a simple front-end to \link{DBI} functions which can be used to load tables from a
+ukbschemas database (or in fact, any database; see \link[DBI:DBI-package]{DBI::DBI-package}).
 }
 \details{
-\code{load_db()} will attempt to open an SQLite database from file \code{file} or
-from connection \code{db}. It will throw errors if the file is not a valid
-database or it is impossible to create a valid connection from \code{db}. Tables
-are read with \link[DBI:dbReadTable]{DBI::dbReadTable} and converted to data frames. The database
-connection is always closed before the function returns its result.
+\code{load_db()} will attempt to open an SQLite database from file \code{file} or from connection \code{db}. It
+will throw errors if the file is not a valid database or it is impossible to create a valid
+connection from \code{db}. Tables are read with \link[DBI:dbReadTable]{DBI::dbReadTable} and converted to data frames. The
+database connection is always closed before the function returns its result.
 }
 \examples{
 \dontrun{

--- a/man/save_db.Rd
+++ b/man/save_db.Rd
@@ -15,36 +15,34 @@ save_db(
 )
 }
 \arguments{
-\item{sch}{List of data frames, representing UK Biobank data schemas (unless
-\code{as_is == TRUE}, in which case any list of data frames is permitted)}
+\item{sch}{List of data frames, representing UK Biobank data schemas (unless \code{as_is == TRUE}, in
+which case any list of data frames is permitted).}
 
-\item{file}{The filename for the schema database. Defaults to \code{""}, which is
-interpreted as \code{paste0("ukb-schemas-", date, ".sqlite")}. If this file
-already exists in directory \code{path}, the session is interactive, and
-\code{overwrite} is not \code{FALSE}, then the user will be prompted to decide whether
-the file should be overwritten.}
+\item{file}{The filename for the schema database. Defaults to \code{""}, which is interpreted as
+\code{paste0("ukb-schemas-", date, ".sqlite")}. If this file already exists in directory \code{path}, the
+session is interactive, and \code{overwrite} is not \code{FALSE}, then the user will be prompted to decide
+whether the file should be overwritten.}
 
-\item{path}{The path to the directory where the file will be saved. Defaults
-to \code{.} (the current directory).}
+\item{path}{The path to the directory where the file will be saved. Defaults to \code{.} (the current
+directory).}
 
-\item{date_str}{The date-stamp for the default filename. Defaults to the
-current date in \code{YYYY-MM-DD} format.}
+\item{date_str}{The date-stamp for the default filename. Defaults to the current date in
+\code{YYYY-MM-DD} format.}
 
 \item{silent}{Do not report progress. Defaults to \code{FALSE}.}
 
-\item{overwrite}{Always overwrite existing files? Helpful for
-non-interactive use. Defaults to \code{FALSE}.}
+\item{overwrite}{Always overwrite existing files? Helpful for non-interactive use. Defaults to
+\code{FALSE}.}
 
-\item{as_is}{Import the schemas into the database without tidying? Defaults
-to \code{FALSE}.}
+\item{as_is}{Import the schemas into the database without tidying? Defaults to \code{FALSE}.}
 }
 \value{
 A database connection object of class
 \link[RSQLite:SQLiteConnection-class]{RSQLite::SQLiteConnection}.
 }
 \description{
-\code{save_db()} saves a list of UK Biobank data schemas (or, if \code{as_is == TRUE},
-any list of data frames) to an SQLite database.
+\code{save_db()} saves a list of UK Biobank data schemas (or, if \code{as_is == TRUE}, any list of data
+frames) to an SQLite database.
 }
 \details{
 \code{save_db()} takes a list of UK Biobank schemas and saves them to an SQLite

--- a/man/ukbschemas.Rd
+++ b/man/ukbschemas.Rd
@@ -16,22 +16,20 @@ ukbschemas(
 \arguments{
 \item{silent}{Do not report progress. Defaults to \code{FALSE}.}
 
-\item{as_is}{Import the schemas into the database without tidying? Defaults
-to \code{FALSE}.}
+\item{as_is}{Import the schemas into the database without tidying? Defaults to \code{FALSE}.}
 
-\item{url_prefix}{First part of the URL at which the schema files can be
-found. For local repositories, the directory with a trailing delimiter (i.e.
-\code{/} or \verb{\\\\} or \verb{\\\\\\\\} as appropriate to your operating system).}
+\item{url_prefix}{First part of the URL at which the schema files can be found. For local
+repositories, the directory with a trailing delimiter (i.e. \code{/} or \verb{\\\\} or \verb{\\\\\\\\} as appropriate
+to your operating system).}
 
-\item{sch_id}{The id numbers of the schemas to download. Type
-\code{SCHEMA_FILENAMES} for reference. Defaults to all.}
+\item{sch_id}{The id numbers of the schemas to download. Type \code{SCHEMA_FILENAMES} for reference.
+Defaults to all.}
 
 \item{cache}{The directory path of the schema download cache. Defaults to
 \code{file.path(Sys.getenv("HOME"), "ukbschemas", "schemas")}.}
 
-\item{nThread}{Number of threads to spawn for parallelisable tasks, such as
-the downloading and importing of the schemas. Defaults to the number of
-logical cores present on the system.}
+\item{nThread}{Number of threads to spawn for parallelisable tasks, such as the downloading and
+importing of the schemas. Defaults to the number of logical cores present on the system.}
 }
 \value{
 A list of objects of class \code{data.frame}.
@@ -40,15 +38,14 @@ A list of objects of class \code{data.frame}.
 Load the UK Biobank data schemas from the Internet or other repository
 }
 \details{
-The UK Biobank data schemas are fetched via the Internet unless a  different
-\code{url_prefix} is provided. If \code{!as_is}, they are tidied. Note that  if the
-table structure has changed (i.e. has been changed by UK Biobank), then the
-function may fail partially or fully unless \code{as_is == TRUE}.
+The UK Biobank data schemas are fetched via the Internet unless a  different \code{url_prefix} is
+provided. If \code{!as_is}, they are tidied. Note that  if the table structure has changed (i.e. has
+been changed by UK Biobank), then the function may fail partially or fully unless
+\code{as_is == TRUE}.
 }
 \note{
-This is a convenience function to load the schemas directly from the UK
-Biobank website. For most purposes, it is recommended to use \link{ukbschemas_db}
-and \link{load_db} instead.
+This is a convenience function to load the schemas directly from the UK Biobank website. For most
+purposes, it is recommended to use \link{ukbschemas_db} and \link{load_db} instead.
 }
 \examples{
 \dontrun{

--- a/man/ukbschemas_db.Rd
+++ b/man/ukbschemas_db.Rd
@@ -18,54 +18,50 @@ ukbschemas_db(
 )
 }
 \arguments{
-\item{file}{The filename for the schema database. Defaults to \code{""}, which is
-interpreted as \code{paste0("ukb-schemas-", date, ".sqlite")}. If this file
-already exists in directory \code{path}, the session is interactive, and
-\code{overwrite} is not \code{FALSE}, then the user will be prompted to decide whether
-the file should be overwritten.}
+\item{file}{The filename for the schema database. Defaults to \code{""}, which is interpreted as
+\code{paste0("ukb-schemas-", date, ".sqlite")}. If this file already exists in directory \code{path}, the
+session is interactive, and \code{overwrite} is not \code{FALSE}, then the user will be prompted to decide
+whether the file should be overwritten.}
 
-\item{path}{The path to the directory where the file will be saved. Defaults
-to \code{.} (the current directory).}
+\item{path}{The path to the directory where the file will be saved. Defaults to \code{.} (the current
+directory).}
 
-\item{date_str}{The date-stamp for the default filename. Defaults to the
-current date in \code{YYYY-MM-DD} format.}
+\item{date_str}{The date-stamp for the default filename. Defaults to the current date in
+\code{YYYY-MM-DD} format.}
 
-\item{overwrite}{Always overwrite existing files? Helpful for non-interactive
-use. Defaults to \code{FALSE}.}
+\item{overwrite}{Always overwrite existing files? Helpful for non-interactive use. Defaults to
+\code{FALSE}.}
 
 \item{silent}{Do not report progress. Defaults to \code{FALSE}.}
 
-\item{as_is}{Import the schemas into the database without tidying? Defaults
-to \code{FALSE}.}
+\item{as_is}{Import the schemas into the database without tidying? Defaults to \code{FALSE}.}
 
-\item{url_prefix}{First part of the URL at which the schema files can be
-found. For local repositories, the directory with a trailing delimiter (i.e.
-\code{/} or \verb{\\\\} or \verb{\\\\\\\\} as appropriate to your operating system).}
+\item{url_prefix}{First part of the URL at which the schema files can be found. For local
+repositories, the directory with a trailing delimiter (i.e. \code{/} or \verb{\\\\} or \verb{\\\\\\\\} as appropriate
+to your operating system).}
 
-\item{sch_id}{The id numbers of the schemas to download. Type
-\code{SCHEMA_FILENAMES} for reference. Defaults to all.}
+\item{sch_id}{The id numbers of the schemas to download. Type \code{SCHEMA_FILENAMES} for reference.
+Defaults to all.}
 
 \item{cache}{The directory path of the schema download cache. Defaults to
 \code{file.path(Sys.getenv("HOME"), "ukbschemas", "schemas")}.}
 
-\item{nThread}{Number of threads to spawn for parallelisable tasks, such as
-the downloading and importing of the schemas. Defaults to the number of
-logical cores present on the system.}
+\item{nThread}{Number of threads to spawn for parallelisable tasks, such as the downloading and
+importing of the schemas. Defaults to the number of logical cores present on the system.}
 }
 \value{
 A database connection object of class \link[RSQLite:SQLiteConnection-class]{RSQLite::SQLiteConnection}.
 }
 \description{
-\code{ukbschemas_db()} generates an SQLite database containing the UK Biobank
-data schemas from http://biobank.ctsu.ox.ac.uk/crystal/schema.cgi.
+\code{ukbschemas_db()} generates an SQLite database containing the UK Biobank data schemas from
+\url{http://biobank.ctsu.ox.ac.uk/crystal/schema.cgi}.
 }
 \details{
-\code{ukbschemas_db()} uses \link{ukbschemas} to load the schemas and \link{save_db} to save
-the result.
+\code{ukbschemas_db()} uses \link{ukbschemas} to load the schemas and \link{save_db} to save the result.
 }
 \examples{
 \dontrun{
-db <- ukbschemas_db(db_path = tempdir())
+db <- ukbschemas_db(path = tempdir())
 }
 
 }


### PR DESCRIPTION
- Set line widths to be a maximum of 100 characters, in line with current CRAN and Linux kernel policies.
- Corrected a few typos in various sections of documentation.